### PR TITLE
Add Utility to Mask Hotspot data as "on-device" data

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ An interactive python script that enables root access on the T-Mobile (Wingtech)
 - Disable OMA-DM update bootstrap
 - On-device root FTP server to browse the filesystem
 - Mood lighting
+- Mask data that would normally be counted as hotspot data as "on-device" data
 
 ## What it doesn't (yet?) feature
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ An interactive python script that enables root access on the T-Mobile (Wingtech)
 - Disable OMA-DM update bootstrap
 - On-device root FTP server to browse the filesystem
 - Mood lighting
-- Mask data that would normally be counted as hotspot data as "on-device" data
+- Mask data that would normally be counted against your hotspot quota as "on-client-device" data
 
 ## What it doesn't (yet?) feature
 

--- a/utils.py
+++ b/utils.py
@@ -192,7 +192,7 @@ def maskHotspot(conn):
     # send command to create /etc/init.d/ttl.ssh, add commands, give it correct permissions, and have it start automatically on boot
     conn.send('echo "iptables -t mangle -I POSTROUTING -o rmnet_data0 -j TTL --ttl-set 64" > /etc/init.d/ttl.sh; echo "ip6tables -t mangle -I POSTROUTING -o rmnet_data0 -j HL --hl-set 64" >> /etc/init.d/ttl.sh; chmod 755 /etc/init.d/ttl.sh; ln -s /etc/init.d/ttl.sh /etc/rc5.d/S98ttl')
     conn.read_very_eager()
-    print('Added TTL rules to mask hotspot data as normal "on-device" data. Will take affect on reboot.')
+    print('Added TTL rules to mask hotspot data as normal "on-device" data. Will take effect on reboot.')
 
 def moodLighting(conn):
     conn.resetIfDead()
@@ -238,13 +238,13 @@ Would you like to set a custom root password? (Y/n):
         5) Enable FTP server for / on port 21 - DO NOT LEAVE OPEN
         6) Remove OMA-DM bootstrap (essentially disables firmware updates, recommended)
         7) Enable mood lighting (look at the battery LED)
-        8) Mask hotspot data as "on-device" data
+        8) Mask hotspot data as "on-client-device" data
         9) Reboot
         10) Quit\n
         Enter option: '''
         )
-        while int(choice) not in range(1,10):
-            choice = input('Please select a valid choice 1-9: ')
+        while int(choice) not in range(1,11):
+            choice = input('Please select a valid choice 1-10: ')
         options= {
             '1': changeRootPwd,
             '2': usrShell,

--- a/utils.py
+++ b/utils.py
@@ -187,6 +187,12 @@ def reboot(conn):
     conn.send('reboot')
     quit()
 
+def maskHotspot(conn):
+    conn.resetIfDead()
+    # send command to create /etc/init.d/ttl.ssh, add commands, give it correct permissions, and have it start automatically on boot
+    conn.send('echo "iptables -t mangle -I POSTROUTING -o rmnet_data0 -j TTL --ttl-set 64" > /etc/init.d/ttl.sh; echo "ip6tables -t mangle -I POSTROUTING -o rmnet_data0 -j HL --hl-set 64" >> /etc/init.d/ttl.sh; chmod 755 /etc/init.d/ttl.sh; ln -s /etc/init.d/ttl.sh /etc/rc5.d/S98ttl')
+    conn.read_very_eager()
+    print('Added TTL rules to mask hotspot data as normal "on-device" data. Will take affect on reboot.')
 
 def moodLighting(conn):
     conn.resetIfDead()
@@ -232,8 +238,9 @@ Would you like to set a custom root password? (Y/n):
         5) Enable FTP server for / on port 21 - DO NOT LEAVE OPEN
         6) Remove OMA-DM bootstrap (essentially disables firmware updates, recommended)
         7) Enable mood lighting (look at the battery LED)
-        8) Reboot
-        9) Quit\n
+        8) Mask hotspot data as "on-device" data
+        9) Reboot
+        10) Quit\n
         Enter option: '''
         )
         while int(choice) not in range(1,10):
@@ -246,8 +253,9 @@ Would you like to set a custom root password? (Y/n):
             '5': ftpEnable,
             '6': disableOmadm,
             '7': moodLighting,
-            '8': reboot,
-            '9': quit
+            '8': maskHotspot,
+            '9': reboot,
+            '10': quit
         }
         options[choice](conn)
         chooseAction(conn)


### PR DESCRIPTION
I've added an option to add some iptables/ip6tables rules that would mask what would normally be counted as hotspot data in the T-mobile dashboard as "on-device" data, that would allow a user on an unlimited plan to have unlimited high-speed data on the hotspot and its connected devices, instead of 5GB/40GB or whatever a plan offers at high-speed which would then be throttled to 3G. 

This would not bypass any sort of network-management or video throttling that may be apart of a customer's plan's terms. Also if a customer is on a straight-up limited data plan, this would not work either.

There's a good read-up [here](https://wirelessjoint.com/viewtopic.php?t=2752) explaining what TTL rules do.

Great work on the project btw!